### PR TITLE
Fixed #74

### DIFF
--- a/lib/helper/stringHandler.js
+++ b/lib/helper/stringHandler.js
@@ -1,0 +1,7 @@
+const stringHandler = {
+  capitalizeFirstLetter(str) {
+    return str.charAt(0).toUpperCase() + str.slice(1);
+  }
+};
+
+module.exports = stringHandler;

--- a/lib/word.js
+++ b/lib/word.js
@@ -1,3 +1,5 @@
+const { capitalizeFirstLetter } = require('./helper/stringHandler');
+
 module.exports = {
   INPUT: {
     POINTS_TO: {
@@ -30,24 +32,24 @@ module.exports = {
     }
   },
   OUTPUT: {
-    pointTo: (house, result) => 'Congratulations ' + house.capitalizeFirstLetter() + '! ' + house.capitalizeFirstLetter() + ' house has ' + result.points + ' points!',
-    pointFrom: (house, result) => 'Alas ' + house.capitalizeFirstLetter() + '. ' + house.capitalizeFirstLetter() + ' house now only has ' + result.points + ' points. Do not dwell on your misdeeds, there is potential for greatness in all students!',
-    getWinner: (house, result) => house.capitalizeFirstLetter() + ' House: ' + result.points + '\n',
+    pointTo: (house, result) => 'Congratulations ' + capitalizeFirstLetter(house) + '! ' + capitalizeFirstLetter(house) + ' house has ' + result.points + ' points!',
+    pointFrom: (house, result) => 'Alas ' + capitalizeFirstLetter(house) + '. ' + capitalizeFirstLetter(house) + ' house now only has ' + result.points + ' points. Do not dwell on your misdeeds, there is potential for greatness in all students!',
+    getWinner: (house, result) => capitalizeFirstLetter(house) + ' House: ' + result.points + '\n',
     RESET_SCORE: 'The scores have been reset and we are ready for another great year at Hogwarts!',
     SAY_HELLO: 'Welcome to Hogwarts everyone!\n Now, in a few moments you will pass through these doors and join your classmates, but before you take your seats, you must be sorted into your houses. They are Gryffindor, Hufflepuff, Ravenclaw, and Slytherin. Now while you\'re here, your house will be like your family. Your triumphs will earn you points. Any rule breaking, and you will lose points. At the end of the year, the house with the most points is awarded the house cup.\n I Albus Dumbledore will award points on your behalf. Just say `10 points to Gryffindor` + or `5 points to @benc` to award points',
     canIJoin: (student, house) => 'Welcome ' + student.capitalizeFirstLetter() + ' the house of ' + house.capitalizeFirstLetter() + ' expects great things from you!',
     OBLIVIATE: 'Poof, even a remembrall wont help you now Gilderoy',
-    getBestStudent: record => 'The head boy/girl of ' + record.house.capitalizeFirstLetter() + ' is @' + record.username + ' with ' + record.points_earned + ' points!',
+    getBestStudent: record => 'The head boy/girl of ' + capitalizeFirstLetter(record.house) + ' is @' + record.username + ' with ' + record.points_earned + ' points!',
     ABOUT_FROGS: '\n I think they\'ve earned some Chocolate Frogs.',
-    getMeanestStudent: record => 'The student most likely to join the Inquisitorial Squad in ' + record.house.capitalizeFirstLetter() + ' is @' + record.username + ' who has taken a total of ' + record.points_taken + ' from their fellow students.',
+    getMeanestStudent: record => 'The student most likely to join the Inquisitorial Squad in ' + capitalizeFirstLetter(record.house) + ' is @' + record.username + ' who has taken a total of ' + record.points_taken + ' from their fellow students.',
     TELL_ME_ABOUT: {
       PERSON: {
         DUMBLEDORE: 'Well my name is Albus Percival Wulfric Brian Dumbledore, I am Headmaster of Hogwarts, I am famous for discovering the 12 uses of Dragon\'s blood, and my favorite candy is Lemon Drops.',
-        student: record => record.username + ' belongs to ' + record.house.capitalizeFirstLetter() + ' House, they have: \n earned: ' + record.points_earned + ' points \n taken: ' + record.points_taken + ' points \n given: ' + record.points_given + ' points \nI\'m sure if you asked them in person they would tell you all this information themself. Good day.',
+        student: record => record.username + ' belongs to ' + capitalizeFirstLetter(record.house) + ' House, they have: \n earned: ' + record.points_earned + ' points \n taken: ' + record.points_taken + ' points \n given: ' + record.points_given + ' points \nI\'m sure if you asked them in person they would tell you all this information themself. Good day.',
         NOT_FOUND: 'I am unfamiliar with that student. In all my years I have never come across such a person. However, if they are over the age of 11 and possess magical abilities, I invite them to come to Hogwarts. Perhaps they are a muggle, or worse a Squib.'
       },
       fromHouse: (house, record) => {
-        let students = 'The students of ' + house.capitalizeFirstLetter() + ' House are:\n';
+        let students = 'The students of ' + capitalizeFirstLetter(house) + ' House are:\n';
 
         record.forEach((name) => {
           students += name.username + '\n';


### PR DESCRIPTION
원래 capitalizeFirstLetter라는 함수는 String의 prototype에 선언 되어있었는데요. lint에서 no-extend-native룰이 풀려있지 않아서 따로 뺐습니다.