### PR TITLE
send fail message when bot scoring and create func to convert id to name

### DIFF
--- a/lib/controller/awardPoints.js
+++ b/lib/controller/awardPoints.js
@@ -4,16 +4,17 @@ const { DB, OUTPUT } = require('../word');
 async function awardPoints(message) {
   const point = parseInt(message.text.split(' ')[0].replace(/[^\d.]/g, ''), 10);
   const userId = message.text.substring(message.text.indexOf('@') + 1).split('>')[0];
-  const botId = this.name;
+  const botName = this.name;
+  const userName = await this.convertToUserName(userId);
 
-  if (typeof botId === 'undefined' || typeof userId === 'undefined' || typeof point === 'undefined') return;
+  if (typeof botName === 'undefined' || typeof userId === 'undefined' || typeof point === 'undefined') return;
+  if (userName === botName) return this.slackBot.awardPointsCallback(message, OUTPUT.FAIL_POINT_TO);
   const Student = new Parse.Object(DB.STUDENT.CALL);
   const query = new Parse.Query(Student);
-  query.equalTo(DB.STUDENT.BOT_ID, botId).equalTo(DB.STUDENT.USER_ID, userId);
+  query.equalTo(DB.STUDENT.BOT_ID, botName).equalTo(DB.STUDENT.USER_ID, userId);
 
   try {
     const results = await query.first();
-
     results.increment(DB.STUDENT.POINT, point);
     results.save();
     this.slackBot.awardPointsCallback(message, OUTPUT.pointTo(results.attributes));

--- a/lib/controller/convertToUserName.js
+++ b/lib/controller/convertToUserName.js
@@ -1,0 +1,13 @@
+async function convertToUserName(key) {
+  const users = await this.slackBot.getUsers();
+  const { members } = users;
+  let userName;
+
+  members.forEach((user) => {
+    const { id, name } = user;
+    if (id === key) userName = name;
+  });
+
+  return userName;
+}
+module.exports = convertToUserName;

--- a/lib/dumbledore.js
+++ b/lib/dumbledore.js
@@ -19,6 +19,7 @@ class Dumbledore {
     this.getUser = require('./controller/getUser').bind(this);
     this.replyWithGithub = require('./controller/replyWithGithub').bind(this);
     this.helpMessage = require('./controller/helpMessage').bind(this);
+    this.convertToUserName = require('./controller/convertToUserName').bind(this);
   }
 
   run() {
@@ -156,20 +157,6 @@ class Dumbledore {
     } else if (message.channel != null && message.channel === this.githubChannel) {
       this.replyWithGithub(message);
     }
-  }
-
-  static async convertToUserID(key) {
-    const users = await this.slackBot.getUsers();
-
-    if (key in users) {
-      return key;
-    }
-    return users.find((userid) => {
-      if (userid.name === key) {
-        return userid.id;
-      }
-      return false;
-    });
   }
 }
 


### PR DESCRIPTION
1. 사용되지 않는 convertToUserID 함수를 제거했습니다.
2. awardPoints 실행될 때 봇(교수님)에게 점수를 부여하는 것을 막았습니다. 이때 userId로 userName을 가져오는 함수가 없는 것 같아서 만들었습니다.