### PR TITLE
fix reactionEvent and delete replayEvent

### DIFF
--- a/lib/controller/awardPoints.js
+++ b/lib/controller/awardPoints.js
@@ -26,8 +26,11 @@ async function awardPoints(message) {
     const results = await query.first();
     results.increment(DB.STUDENT.POINT, point);
     results.save();
-    this.slackBot.awardPointsCallback(message, OUTPUT.pointTo(results.attributes));
-    this.slackBot.reactionPointsCallback(message, OUTPUT.reaction(results.attributes));
+    if (this.isChatMessageEvent(message)) {
+      this.slackBot.awardPointsCallback(message, OUTPUT.pointTo(results.attributes));
+    } else if (this.isReactionEvent(message)) {
+      this.slackBot.reactionPointsCallback(message, OUTPUT.reaction(results.attributes));
+    }
   } catch (err) {
     console.log(err);
   }

--- a/lib/controller/awardPoints.js
+++ b/lib/controller/awardPoints.js
@@ -2,11 +2,19 @@ const Parse = require('parse/node');
 const { DB, OUTPUT } = require('../word');
 
 async function awardPoints(message) {
-  const point = parseInt(message.text.split(' ')[0].replace(/[^\d.]/g, ''), 10);
-  const userId = message.text.substring(message.text.indexOf('@') + 1).split('>')[0];
+  let point = 0;
+  let userId = '';
   const botName = this.name;
-  const userName = await this.convertToUserName(userId);
 
+  if (this.isReactionEvent(message)) {
+    point = 10;
+    userId = message.item_user;
+  } else if (this.isChatMessageEvent(message)) {
+    userId = ([(message.text.substring(message.text.indexOf('@') + 1).split('>')[0])]).join();
+    point = parseInt(message.text.split(' ')[0].replace(/[^\d.]/g, ''), 10);
+  }
+  const userName = await this.convertToUserName(userId);
+  // const user = message.item_user;
   if (typeof botName === 'undefined' || typeof userId === 'undefined' || typeof point === 'undefined') return;
   if (userName === botName) return this.slackBot.awardPointsCallback(message, OUTPUT.FAIL_POINT_TO);
   const Student = new Parse.Object(DB.STUDENT.CALL);
@@ -19,6 +27,7 @@ async function awardPoints(message) {
     results.increment(DB.STUDENT.POINT, point);
     results.save();
     this.slackBot.awardPointsCallback(message, OUTPUT.pointTo(results.attributes));
+    this.slackBot.reactionPointsCallback(message, OUTPUT.reaction(results.attributes));
   } catch (err) {
     console.log(err);
   }

--- a/lib/dumbledore.js
+++ b/lib/dumbledore.js
@@ -99,18 +99,9 @@ class Dumbledore {
     if (this.isChatMessageEvent(message)) {
       this.parseMessage(message);
       this.saveMessage(message);
-    } else if (this.isReplayEvent(message)) {
-      const { user } = message.message.replies[message.message.reply_count - 1];
-      const point = 5;
-      this.awardPoints(this.name, user, point);
-      this.saveMessage(message);
     } else if (this.isReactionEvent(message)) {
-      const user = message.item_user;
-      const point = 10;
       if (message.type === 'reaction_added') {
-        this.awardPoints(this.name, user, point);
-      } else {
-        this.awardPoints(this.name, user, -point);
+        this.awardPoints(message);
       }
       this.saveMessage(message);
     }
@@ -137,25 +128,15 @@ class Dumbledore {
     return isChatMessage && isChannelConversation && !isFromDumbledore && !isFromSlackbot;
   }
 
-  isReplayEvent(message) {
-    if (typeof message.subtype === 'undefined') return false;
-    const isReplayMessage = message.type === 'message' && message.subtype === 'message_replied';
-    const isChannelConversation = (typeof message.channel === 'string' && message.channel[0] === 'C');
-    const isSameUser = message.message.user === message.message.replies[message.message.reply_count - 1].user;
-    const isFromSlackbot = message.message.user === this.user.id;
-
-    return isReplayMessage && isChannelConversation && !isSameUser && !isFromSlackbot;
-  }
-
   isReactionEvent(message) {
     if (typeof message.item === 'undefined') return false;
     const isReactionMessage = message.type === 'reaction_added' || message.type === 'reaction_removed';
     const isScoreReaction = message.reaction === '100';
     const isChannelConversation = (typeof message.item.channel === 'string' && message.item.channel[0] === 'C');
     const isSameUser = message.user === message.item_user;
-    const isFromSlackbot = message.item_user === this.user.id;
+    const isToSlackbot = message.item_user === this.user.id;
 
-    return isReactionMessage && isScoreReaction && isChannelConversation && !isSameUser && !isFromSlackbot;
+    return isReactionMessage && isScoreReaction && isChannelConversation && !isSameUser && !isToSlackbot;
   }
 
   parseMessage(message) {

--- a/lib/helper/slackBot.js
+++ b/lib/helper/slackBot.js
@@ -17,6 +17,11 @@ class SlackBot extends Bot {
     await this.postMessageToChannel(channel.name, message, { as_user: true });
   }
 
+  async reactionPointsCallback(originalMessage, message) {
+    const channel = await this.getChannelById(originalMessage.item.channel);
+    await this.postMessageToChannel(channel.name, message, { as_user: true });
+  }
+
   async announcePlainString(originalMessage, message) {
     const channel = await this.getChannelById(originalMessage.channel);
 

--- a/lib/word.js
+++ b/lib/word.js
@@ -20,6 +20,7 @@ module.exports = {
     }
   },
   OUTPUT: {
+    reaction: result => 'Congratulations ' + result.userName + ' has ' + result.point + ' points by reaction!',
     pointTo: result => 'Congratulations ' + result.userName + ' has ' + result.point + ' points!',
     SAY_HELLO: 'Welcome to Hogwarts everyone!\n Now, in a few moments you will pass through these doors and join your classmates. Your triumphs will earn you points. Any rule breaking, and you will lose points. I Albus Dumbledore will award points on your behalf. Just say `5 points to @benc` to award points. If you want to know the best student, just say `professor best student`. Then good luck everyone!',
     getBestStudent: record => 'High score (boy/girl): ' + record.userName + ' with ' + record.point + ' points!',

--- a/spec/helperSpec.js
+++ b/spec/helperSpec.js
@@ -32,6 +32,7 @@ describe('In helper', function () {
   });
 
   it('Any functions should not be `undefined` in slackBot', () => {
+    expect(slackBot.reactionPointsCallback).toBeDefined();
     expect(slackBot.awardPointsCallback).toBeDefined();
     expect(slackBot.announcePlainString).toBeDefined();
     expect(slackBot.getUserList).toBeDefined();


### PR DESCRIPTION
코드가 변경되면서 작동되지 않았던 reaction event를 인자를 message하나 받는것으로 수정하여 정삭적으로 작동하게 수정하였습니다. 그리고 리액션 점수부여에따른 메시지도 추가하였습니다.!

그리고 #158 참고하여 replayEvent는 일단 삭제하였습니다!